### PR TITLE
Edit urls

### DIFF
--- a/docs/api/titanium.md
+++ b/docs/api/titanium.md
@@ -1,3 +1,6 @@
+---
+editUrl: https://github.com/appcelerator/titanium_mobile/edit/master/apidoc/Titanium/Titanium.yml
+---
 # Titanium
 
 <TypeHeader/>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1431,9 +1431,9 @@
       "dev": true
     },
     "@vuepress/shared-utils": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@vuepress/shared-utils/-/shared-utils-1.5.4.tgz",
-      "integrity": "sha512-HCeMPEAPjFN1Ongii0BUCI1iB4gBBiQ4PUgh7F4IGG8yBg4tMqWO4NHqCuDCuGEvK7lgHy8veto0SsSvdSKp3g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vuepress/shared-utils/-/shared-utils-1.6.0.tgz",
+      "integrity": "sha512-+TMHgW7gmVY2lRX5qpPbsLkbxTBbzRo+Ar05tvEI0bAG0c6v2gWyQr3BchdbLyRJxrAVk530PABAjM8roDJ9bw==",
       "dev": true,
       "requires": {
         "chalk": "^2.3.2",
@@ -9899,9 +9899,9 @@
       "optional": true
     },
     "titanium-docgen": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/titanium-docgen/-/titanium-docgen-4.7.0.tgz",
-      "integrity": "sha512-quwtJzuzflnudpsr+m0HXexEiiI8yKn6micq/Ofl/XVG1XV9mR83jomC5TqTzyxJBYKZNs/fgE7C97YzCs+qcw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/titanium-docgen/-/titanium-docgen-4.8.0.tgz",
+      "integrity": "sha512-CRv7rI7nbVCvzKV5qxk8V3uN4zkkbIBaj7BbqMKKpX+BqWRuea+JH/88sEx0Db0z2TQ+XzGEMedOvxwWyS70zg==",
       "dev": true,
       "requires": {
         "colors": "^1.4.0",
@@ -10698,15 +10698,15 @@
       }
     },
     "vuepress-plugin-apidocs": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-apidocs/-/vuepress-plugin-apidocs-4.7.0.tgz",
-      "integrity": "sha512-19NGkVEE0BEubXE9y1KvIhM6fFAmhL0sMc6HVNf6sWO9XwcTyH09egJiSWK8ETUN2EquszM9jpdIBlwlGYo5Rg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-apidocs/-/vuepress-plugin-apidocs-4.8.0.tgz",
+      "integrity": "sha512-xEpo2Lhi/7Fvexqcp+iT27VrclFK6O/DPDqZNcvy/rw7h4AtDGjzjBVRd9hs4fKv4KtHl3dGZxkeuzhDugjz6Q==",
       "dev": true,
       "requires": {
         "@vuepress/shared-utils": "^1.5.2",
         "axios": "^0.19.0",
         "fs-extra": "^8.1.0",
-        "titanium-docgen": "^4.7.0",
+        "titanium-docgen": "^4.8.0",
         "vue-content-loader": "^0.2.2"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1382,9 +1382,9 @@
       }
     },
     "@vuepress/plugin-nprogress": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-1.5.2.tgz",
-      "integrity": "sha512-PtiV5u9hHZJNPmyKs7s++f4GCJTuvPP25aIASi06vKACr/+Ier5XC7PvOwUvS1LbG6HAGRbQpokmeP1aVbrI6w==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-nprogress/-/plugin-nprogress-1.6.0.tgz",
+      "integrity": "sha512-dhIho2z33aGjPavcdVYRlqR3+ZC5Vd3FPd+HkRP8MdIIFxhVR1HLFxVgaSUcASOCGAwuG58OB2RStvgMQLtTEA==",
       "dev": true,
       "requires": {
         "nprogress": "^0.2.0"
@@ -1425,9 +1425,9 @@
       }
     },
     "@vuepress/plugin-search": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-1.5.2.tgz",
-      "integrity": "sha512-/n0W7lQhBCj7vrIhU6VL8ZlUnWBru83W4w0gGNxzXDzZ1AMRJRnQDamBjKAWNd+WMYz8LA2LbJy1rCCds1Mu2Q==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@vuepress/plugin-search/-/plugin-search-1.6.0.tgz",
+      "integrity": "sha512-Js7zRmM6/b6dYfnJsSP2MQN0lzjUfSX8l3z9y/QHxK8BaXIx7LdTcQY6FGK4pxuwlWcg02CIUS5BMc1gZKn6Nw==",
       "dev": true
     },
     "@vuepress/shared-utils": {
@@ -10801,9 +10801,9 @@
       }
     },
     "vuepress-theme-titanium": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/vuepress-theme-titanium/-/vuepress-theme-titanium-4.5.1.tgz",
-      "integrity": "sha512-yWDbv4Omwk611ftN0WEAf30n4dE0TbyH7ROPYTt3u185hhE8qRiba9HJBwm8CU2CKfp+Yjv5y24V/OHGfSqJzQ==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/vuepress-theme-titanium/-/vuepress-theme-titanium-4.8.0.tgz",
+      "integrity": "sha512-c56nwtZh+XukdHLZB9wncAilKpwaATLbtk8CYs0ZvaNemWkqlMjTc3ShR/wNjg89vR6XMCrD9rJ2QS4iSqVJaQ==",
       "dev": true,
       "requires": {
         "@vuepress/plugin-nprogress": "^1.5.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@vuepress/plugin-back-to-top": "^1.5.2",
     "gh-pages": "^3.1.0",
     "vuepress": "^1.5.2",
-    "vuepress-plugin-apidocs": "^4.7.0",
+    "vuepress-plugin-apidocs": "^4.8.0",
     "vuepress-plugin-versioning": "^4.5.0",
     "vuepress-theme-titanium": "^4.8.0",
     "vuex": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "vuepress": "^1.5.2",
     "vuepress-plugin-apidocs": "^4.7.0",
     "vuepress-plugin-versioning": "^4.5.0",
-    "vuepress-theme-titanium": "^4.5.1",
+    "vuepress-theme-titanium": "^4.8.0",
     "vuex": "^3.4.0",
     "vuex-router-sync": "^5.0.0"
   },

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -98,7 +98,10 @@ async function generateMarkDownForType(metadata, targetVersion) {
   }
 
   const mdContent =
-`# ${metadata.name}
+`---
+editUrl: ${metadata.editUrl}
+---
+# ${metadata.name}
 
 <TypeHeader/>${overview}${examples}<ApiDocs/>
 `;


### PR DESCRIPTION
Relates to appcelerator/docs-devkit#47

Changed the migrate script to set the api page front matter's editUrl to be the one from the api.json output for the type. These PRs combined should make the "Edit this page on Github" link work properly to point readers at the underlying xml files that are the source of truth.

Combined, this should fix #15 