### PR TITLE
fix: re-apply basic css styles and fix sticky sidebars

### DIFF
--- a/docs/.vuepress/styles/base.styl
+++ b/docs/.vuepress/styles/base.styl
@@ -1,0 +1,27 @@
+/* Re-apply some base styles that were overwritten by Tailwind */
+
+@css {
+  html {
+    line-height: 1.15
+  }
+
+  p, ul, dl {
+    @apply my-5
+  }
+
+  ul {
+    @apply list-disc
+  }
+
+  li > p {
+    @apply my-0
+  }
+
+  dl > dd {
+    @apply ml-8
+  }
+
+  hr {
+    @apply my-12
+  }
+}

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -2,12 +2,11 @@
 @tailwind components
 @tailwind utilities
 
+@import base
 @import buttons
 
-html,
 body
   overflow-x hidden
-  width 100%
 
 .landing
   .content:not(.custom)


### PR DESCRIPTION
This re-applies a couple of basic css styles that were reset by adding Tailwind CSS. It also makes the sidebars sticky again so they don't scroll with the page.