### PR TITLE
fix: remove Windows add on docs when generating docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "docs:dev": "vuepress dev docs --temp .temp",
     "docs:build": "NODE_OPTIONS=\"--max-old-space-size=6144\" vuepress build docs && cp CNAME docs/.vuepress/dist",
     "docs:version": "vuepress version docs",
-    "docs:metadata": "vuepress metadata docs ../titanium_mobile/apidoc ../titanium_mobile_windows/apidoc",
-    "docs:migrate": "node ./scripts/migrate ../titanium_mobile/apidoc ../titanium_mobile_windows/apidoc",
+    "docs:metadata": "vuepress metadata docs ../titanium_mobile/apidoc",
+    "docs:migrate": "node ./scripts/migrate ../titanium_mobile/apidoc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
The existence of the Windows docs was causing some APIs to be incorrectly generated with unsupported platforms

After this change Ti.Contacts.getAllGroups (amongst others) will correctly show that it is only supported on iOS.

I haven't updated the api.json file in this PR, but can do so if wanted