### PR TITLE
fix: replace custom landing page with default home

### DIFF
--- a/website/pages/README.md
+++ b/website/pages/README.md
@@ -1,6 +1,15 @@
 ---
-editLink: false
-pageClass: landing
+home: true
+heroImage: /images/titanium-logo.png
+heroText: Titanium Mobile
+tagline: Write in JavaScript. Run native everywhere.
+actionText: Get Started →
+actionLink: /guide/Titanium_SDK/
+features:
+- title: Titanium SDK
+  details: Titanium lets you develop cross-platform native mobile applications and build great mobile experiences using JavaScript.
+- title: Rich APIs
+  details: Access hundreds of native UI and non-visual components (such as networks and media APIs) within your application.
+- title: Module Ecosystem
+  details: Easily include third-party modules in your apps with Titanium's wide selection of community modules and premium support integrations.
 ---
-
-<LandingPage />


### PR DESCRIPTION
The current landing page contains unfinished assets and outdated content. This will temporarily replace it with the default home page shipped with the theme until the landing page is polished.