### PR TITLE
feat(all): add github community link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -52,9 +52,14 @@ module.exports = {
                 link: 'https://tidev.slack.com'
               },
               {
-                text: 'GitHub community',
+                text: 'GitHub Discussions',
                 link: 'https://github.com/tidev/titanium_mobile/discussions'
-              },
+              }
+            ]
+          },
+          {
+            text: 'Contribute',
+            items: [
               {
                 text: 'Contribution Guide',
                 link: '/contribute.md'

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -52,6 +52,10 @@ module.exports = {
                 link: 'https://tidev.slack.com'
               },
               {
+                text: 'GitHub community',
+                link: 'https://github.com/tidev/titanium_mobile/discussions'
+              },
+              {
                 text: 'Contribution Guide',
                 link: '/contribute.md'
               },


### PR DESCRIPTION
Adds a link to our `GitHub community` below the Slack link and move the contribution links into a separate section:

![Screenshot_20220421_133804](https://user-images.githubusercontent.com/4334997/164450228-527a1c4e-8727-4597-8376-3da1a7277da6.png)


