### PR TITLE
fix(all): missing warning boxes, border colors

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -77,6 +77,7 @@ body
   --bg-warning: #fff5e7;
   --bg-tip: #ecf7f3;
   --link-color: #d22630;
+  --bg-danger: #ffebee;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -94,6 +95,7 @@ body
   --bg-warning: #000;
   --bg-tip: #000;
   --link-color: #f54b49;
+  --bg-danger: #000;
 }
 
 :root.dark {
@@ -111,6 +113,7 @@ body
 --bg-warning: #000;
 --bg-tip: #000;
 --link-color: #f54b49;
+--bg-danger: #000;
 }
 
 html, body, header, .navbar .links, .dropdown-wrapper .nav-dropdown, .sidebar,
@@ -136,10 +139,14 @@ body, .sidebar-heading, a.sidebar-link, a.content-sidebar-link, .suggestions a s
   color: var(--text-color) !important;
 }
 
-.navbar, .sidebar, .content-sidebar, .content-sidebar-links {
+.navbar, .sidebar, .content-sidebar, .content-sidebar-links,
+.dropdown-wrapper .nav-dropdown, .suggestions {
   border-color: var(--bg-border) !important;
 }
 
+.dropdown-wrapper .nav-dropdown .dropdown-item h4 {
+border-color: var(--bg-border) !important;
+}
 
 .docs-card {
   background-color: var(--bg-color2) !important;
@@ -154,6 +161,10 @@ body, .sidebar-heading, a.sidebar-link, a.content-sidebar-link, .suggestions a s
 
 .custom-block.tip {
   background-color: var(--bg-tip) !important;
+}
+
+.custom-block.danger {
+  background-color: var(--bg-danger) !important;
 }
 
 div[class*="language-"], div[class*="language-"] code {


### PR DESCRIPTION
**Missed the warning boxes:**
![Screenshot_20220524_131336](https://user-images.githubusercontent.com/4334997/170022488-fdb21fdd-c94c-453c-8578-8d7cad3e72be.png)


**new:**
![Screenshot_20220524_131724](https://user-images.githubusercontent.com/4334997/170022590-5d2cf017-e061-42aa-9ac0-0fb95c51a13c.png)
<hr/>

**and made the border of the menu not white:**
![Screenshot_20220524_131656](https://user-images.githubusercontent.com/4334997/170022671-06de92ce-196f-46b4-a754-82017ce7f627.png)
**so its not that bright**
