### PR TITLE
fix: re-added blog link

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -91,10 +91,10 @@ module.exports = {
           {
             text: 'News',
             items: [
-              // {
-              //   text: 'Blog',
-              //   link: 'https://appcelerator.com/blog'
-              // },
+              {
+                text: 'Blog',
+                link: 'https://tidev.io/blog'
+              },
               {
                 text: 'Titanium SDK Twitter',
                 link: 'https://twitter.com/titaniumsdk'


### PR DESCRIPTION
Re-added blog link with target https://tidev.io/blog

<img width="261" alt="Bildschirmfoto 2022-05-27 um 08 51 30" src="https://user-images.githubusercontent.com/1126641/170646741-4f08b62c-492e-430f-8ebe-9ea3368ee76b.png">
