### PR TITLE
Remove api docs before generating, trigger deploy if there were changes

### DIFF
--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -156,6 +156,14 @@ jobs:
         run: npm run docs:migrate  -- ../ti.map/apidoc ../ti.facebook/apidoc ../ti.coremotion/apidoc ../ti.crypto/apidoc ../ti.urlsession/apidoc ../titanium-identity/apidoc ../ti.playservices/apidoc ../ti.geofence/apidoc ../appcelerator.ble/apidoc ../appcelerator.bluetooth/apidoc ../appcelerator.https/apidoc ../appcelerator.encrypteddatabse/apidoc ../titanium-web-dialog/apidoc ../ti.barcode/apidoc ../titanium-apple-sign-in/apidoc
 
       - name: Commit changes
+        id: committed
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           repository: titanium-docs
+      
+      - name: Repository Dispatch
+        if: steps.committed.outputs.changes_detected == 'true'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: deploy
+          token: ${{ secrets.REGEN_BUILDS_DOCS_GITHUB_TOKEN }}

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -147,7 +147,7 @@ jobs:
         if: steps.node-cache.outputs.cache-hit != 'true'
 
       - name: Remove old API docs to generate new ones
-        run: rm -rf docs/api
+        run: npm run clean:api
 
       - name: Generate metadata
         run: npm run docs:metadata -- ../ti.map/apidoc ../ti.facebook/apidoc ../ti.coremotion/apidoc ../ti.crypto/apidoc ../ti.urlsession/apidoc ../titanium-identity/apidoc ../ti.playservices/apidoc ../ti.geofence/apidoc ../appcelerator.ble/apidoc ../appcelerator.bluetooth/apidoc ../appcelerator.https/apidoc ../appcelerator.encrypteddatabse/apidoc ../titanium-web-dialog/apidoc ../ti.barcode/apidoc ../titanium-apple-sign-in/apidoc

--- a/.github/workflows/regen.yml
+++ b/.github/workflows/regen.yml
@@ -146,6 +146,9 @@ jobs:
         run: npm install
         if: steps.node-cache.outputs.cache-hit != 'true'
 
+      - name: Remove old API docs to generate new ones
+        run: rm -rf docs/api
+
       - name: Generate metadata
         run: npm run docs:metadata -- ../ti.map/apidoc ../ti.facebook/apidoc ../ti.coremotion/apidoc ../ti.crypto/apidoc ../ti.urlsession/apidoc ../titanium-identity/apidoc ../ti.playservices/apidoc ../ti.geofence/apidoc ../appcelerator.ble/apidoc ../appcelerator.bluetooth/apidoc ../appcelerator.https/apidoc ../appcelerator.encrypteddatabse/apidoc ../titanium-web-dialog/apidoc ../ti.barcode/apidoc ../titanium-apple-sign-in/apidoc
       

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "private": true,
   "main": "index.js",
   "scripts": {
-    "clean:api": "rm -rf docs/api; rm -f docs/.vuepress/api.json",
-    "clean:guide": "rm -rf docs/guide; rm -rf docs/.vuepress/public/images/guide; rm -f docs/.vuepress/guide.json",
+    "clean:api": "rm -rf docs/api",
     "docs:dev": "vuepress dev docs --temp .temp",
     "docs:build": "node ./scripts/generate-guides && NODE_ENV=production NODE_OPTIONS=\"--max-old-space-size=6144\" vuepress build docs",
     "docs:version": "vuepress version docs",


### PR DESCRIPTION
This removes the api docs before running the generation scripts and also adds triggering a deploy if there were changes. It also removes the `clean:guide` npm script as that was only useful when the guides were being generated from the wiki, now it would remove all guides content which would be bad.

This will require someone to create a `REGEN_BUILDS_DOCS_GITHUB_TOKEN` environment variable in GitHub.