### PR TITLE
refactor: remove sidebar items that no longer exist

### DIFF
--- a/docs/.vuepress/api.json
+++ b/docs/.vuepress/api.json
@@ -72,7 +72,6 @@
 		"path": "/api/titanium",
 		"children": [
 			["titanium/accelerometer", "Accelerometer"],
-			["titanium/analytics", "Analytics"],
 			{
 				"title": "Android",
 				"path": "/api/titanium/android",
@@ -206,8 +205,7 @@
 						"title": "Socket",
 						"path": "/api/titanium/network/socket",
 						"children": [
-							["titanium/network/socket/tcp", "TCP"],
-							["titanium/network/socket/udp", "UDP"]
+							["titanium/network/socket/tcp", "TCP"]
 						]
 					},
 					["titanium/network/tcpsocket", "TCPSocket"]


### PR DESCRIPTION
The Analytics namespace has been removed as it required the platform connectivity, and the UDP namespace was a Windows only API. I haven't removed the Apple Sign In page as that _should_ exist, it just didn't get generated for some reason