### PR TITLE
Fix SDK menu order

### DIFF
--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/README.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/README.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK Release Notes 12.x
-weight: '9'
+weight: '8'
 ---
 
 # Titanium SDK Release Notes 12.x


### PR DESCRIPTION
* lowering the weight to push the menu up in the list

**edit:**
I'm not seeing the menu entry at all in my local test environment. So I can't test it offline. But seeing that all the other "Release note" folders have a higher weight it should fix it by lowering it below the "release note 11" weight