### PR TITLE
docs: adjust FAQ and matrix

### DIFF
--- a/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
@@ -21,7 +21,7 @@ Besides this documentation you can look at [from zero to app](https://fromzeroto
 ## No iOS simulator is visible or it will say "Unable to find an iOS Simulator"
 
 Go to Xcode and make sure `preferences->locations->Command Line Tools` is set to the correct Xcode path. Even if it is set you sometimes have to open and select it again in order accept a permissions request.
-If you are running the latest XCode make sure you've selected the latest Titanium SDK with e.g. `ti sdk seelct 12.2.0.GA` (Xcode 15 support was added to ioslib that is included in 12.2.0.GA)
+If you are running the latest Xcode make sure you've selected the latest Titanium SDK with e.g. `ti sdk select 12.2.0.GA` (Xcode 15 support was added to ioslib that is included in 12.2.0.GA)
 
 ## iOS build error: "Unable to find any non-expired Ad Hoc or Enterprise Ad Hoc provisioning profiles that match the app id"
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
@@ -21,6 +21,7 @@ Besides this documentation you can look at [from zero to app](https://fromzeroto
 ## No iOS simulator is visible or it will say "Unable to find an iOS Simulator"
 
 Go to Xcode and make sure `preferences->locations->Command Line Tools` is set to the correct Xcode path. Even if it is set you sometimes have to open and select it again in order accept a permissions request.
+If you are running the latest XCode make sure you've selected the latest Titanium SDK with e.g. `ti sdk seelct 12.2.0.GA` (Xcode 15 support was added to ioslib that is included in 12.2.0.GA)
 
 ## iOS build error: "Unable to find any non-expired Ad Hoc or Enterprise Ad Hoc provisioning profiles that match the app id"
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
@@ -20,7 +20,7 @@ Besides this documentation you can look at [from zero to app](https://fromzeroto
 
 ## No iOS simulator is visible or it will say "Unable to find an iOS Simulator"
 
-Go to Xcode and make sure `preferences->locations->Command Line Tools` is set to the correct Xcode path.
+Go to Xcode and make sure `preferences->locations->Command Line Tools` is set to the correct Xcode path. Even if it is set you sometimes have to open and select it again in order accept a permissions request.
 
 ## iOS build error: "Unable to find any non-expired Ad Hoc or Enterprise Ad Hoc provisioning profiles that match the app id"
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_Android_SDK.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_Android_SDK.md
@@ -17,7 +17,6 @@ Titanium requires the Android SDK Tools to be installed in order to allow you to
 Remember that JDK (Oracle or OpenJDK) is a prerequisite for Android development and should be installed first. You need at least JDK 11 installed. See [Installing Oracle JDK](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Prerequisites/Installing_Oracle_JDK/) for instructions.
 :::
 
-
 Use "Android Studio" from the [Android Studio and SDK tools](https://developer.android.com/studio) to install the SDK and tools.
 
 ### Required Android Packages
@@ -26,79 +25,15 @@ As of Titanium 9.0.0, the build system will automatically download the Android S
 
 ![android_platform_tools.png](android_platform_tools.png)
 
-<details>
-<summary><b>Details for Titanium 8.x.x and later</b></summary>
-
-For Titanium 8.x.x, you need to installed the following packages via the Android SDK Manager yourself:
-
-| Package | Minimum Version |
-| --- | --- |
-| Android SDK Tools | Rev 28 |
-| Android SDK Build-tools | Rev 23 |
-| Android SDK Platform (API Level) | API Level 29 for Titanium 8.3.x<br /><br />API Level 28 for Titanium version older than 8.3.0 |
-
-</details>
-
-
 Take caution before upgrading these packages, as changes to the way they work has broken the Titanium toolchain a number of times in the past. Although these problems are often beyond our control, we always do our utmost to fix them as soon as we are made aware of them.
 
 With this in mind, it's important to only upgrade these packages _between_ major projects, so that you have time to fix any problems that may result. Always consult the Android Tools [Release Notes](http://developer.android.com/sdk/tools-notes.html) and [Known Issues](http://tools.android.com/knownissues) first, and refer to our [Installation Troubleshooting](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installation_Troubleshooting/) guide to check whether there are any further actions that need to be taken to make the Titanium and the Android SDK compatible.
-:::
 
 ### Android SDK / Target Android platform
 
 Each Titanium SDK supports building against a specific range of Android versions, as shown in the following table, and requires at least one of these versions to be installed. If you specify a `android:targetSDKVersion` in the `tiapp.xml` file of your project, you must specify one within the target min and max values. The minimum Android/SDK version column indicates the minimum version of Android that a device can run, which a Titanium application supports.
 
-#### Supported versions
-
-| Titanium SDK Version | Min Target Android Version  <br />(android:targetSdkVersion) | Max Target Android Version  <br />(android:targetSdkVersion) | Min Supported Android Version  <br />(android:minSdkVersion) |
-| --- | --- | --- | --- |
-| 12.0.0 - latest\* | 6.0.x (API 23) | 13.0.x (API 33) | 5.0.x (API 21) |
-| 10.1.0 - 11.1.1 | 6.0.x (API 23) | 12.0.x (API 31) | 5.0.x (API 21) |
-| 10.0.0 - 10.0.2 | 6.0.x (API 23) | 11.0.x (API 30) | 5.0.x (API 21) |
-| 9.3.0 - 9.3.2 | 6.0.x (API 23) | 11.0.x (API 30) | 4.4.x (API 19) |
-
-::: warning ⚠️ Notes
-\* As of 10.1.0, Titanium requires JDK 11 or higher to build Android projects.
-:::
-
-
-
-<details>
-<summary><b>Unsupported versions</b></summary>
-
-
-| Titanium SDK Version | Min Target Android Version  <br />(android:targetSdkVersion) | Max Target Android Version  <br />(android:targetSdkVersion) | Min Supported Android Version  <br />(android:minSdkVersion) |
-| --- | --- | --- | --- |
-| 8.3.0 - 9.2.2 | 6.0.x (API 23) | 10.0.x (API 29) | 4.4.x (API 19) |
-| 8.0.0 - 8.2.2 | 6.0.x (API 23) | 9.0.x (API 28) | 4.4.x (API 19) |
-| 7.5.0 - 7.5.1 | 6.0.x (API 23) | 9.0.x (API 28) | 4.1.x (API 16) |
-| 7.3.0 - 7.4.1 | 6.0.x (API 23) | 8.1.x (API 27) | 4.1.x (API 16) |
-| 7.0.0 - 7.2.0 | 6.0.x (API 23) | 7.0.x (API 25) | 4.1.x (API 16) |
-| 6.2.0 - 6.3.0 | 7.1.x (API 25) | 6.0.x (API 23) | 4.1.x (API 16) |
-| 6.0.0 - 6.1.x | 6.0.x (API 23) | 6.0.x (API 23) | 4.1.x (API 16) |
-| 5.1.0 - 5.5.x | 6.0.x (API 23) | 6.0.x (API 23) | 4.0.x (API 14) |
-| 5.0.0 - 5.0.x | 5.0.x (API 21) | 6.0.x (API 23) | 4.0.x (API 14) |
-| 4.0.0 - 4.1.x | 5.0.x (API 21) | 5.1.x (API 22) | 4.0.x (API 14) |
-| 3.4.1 - 3.5.1 | 4.0.x (API 14)\* | 5.0.x (API 21)\*\* | 2.3.x (API 10) |
-| 3.3.0 - 3.4.0 | 4.0.x (API 14)\* | 4.4.x (API 19) | 2.3.x (API 10) |
-| 3.2.0 - 3.2.3 | 2.3.x (API 10)\* | 4.4.x (API 19) | 2.3.x (API 10) |
-| 3.1.2 - 3.1.3 | 2.3.x (API 10) | 4.3.x (API 18) | 2.3.x (API 10) |
-| 3.1.1 | 2.3.x (API 10) | 4.2.x (API 17) | 2.3.x (API 10) |
-| 3.1.0 | 2.2 (API 8) | 4.2.x (API 17) | 2.2 (API 8) |
-| 2.1.2 - 3.0.2 | 2.2 (API 8) | 4.1.x (API 16) | 2.2 (API 8) |
-| 2.0 - 2.1.1 | 2.2 (API 8) | 4.0.x (API 15) | 2.2 (API 8) |
-| 1.8.x | 2.2 (API 8) | 3.x.x (API 11) | 2.2 (API 8) |
-| 1.7.x | 2.1 (API 7) | 3.x.x (API 11) | 2.1 (API 7) |
-
-::: warning ⚠️ Notes
-\* If you are building an Android module, you need to have Android SDK 6.0.x (API 23) installed if using Release 6.0.0 and greater.
-
-\*\* The Titanium SDK does not support the [Android 4.4W SDK](http://developer.android.com/wear/index.html) (API 20), also known as the Android Wear SDK.
-:::
-
-</details>
-
+For a list of supported version please refer to the [Titanium Compatibility Matrix](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Titanium_Compatibility_Matrix/).
 
 Most mobile device manufacturers have been licensed to use Google's enhanced API, which provides support for Maps and other functionality. If this is the case for your target devices, you will need to install the relevant Google packages, listed as _Google APIs by Google Inc., Android API x..._ by the **Android SDK Manager** tool. In Studio, choose the SDKs with the naming format "Google APIs x.x" to use the enhanced APIs, or those without the "Google APIs" prefix otherwise.
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_iOS_SDK.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_iOS_SDK.md
@@ -17,8 +17,6 @@ This guide describes where to obtain and how to install the Xcode developer tool
 
 Titanium requires Xcode to be installed in order for you to develop iOS applications.
 
-![download_05](/images/guide/download/attachments/29004836/download_05.png)
-
 There are two ways to obtain Xcode, the application that installs and manages iOS SDKs:
 
 1. Launch the _App Store_ application, found in the `Applications` folder, and search for and install "Xcode" (includes the stable iOS and watchOS SDKs).
@@ -30,78 +28,8 @@ Both of the above options are free of charge, although may require credit card d
 ### Xcode
 
 To develop for iOS, Titanium requires Apple's Xcode suite of tools.
+For a list of supported version please refer to the [Titanium Compatibility Matrix](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Titanium_Compatibility_Matrix/).
 
-Each Titanium SDK supports a specific range of Xcode versions, shown in the table below.
-
-#### Supported versions of Xcode
-
-| Titanium SDK Version | Min Xcode Version | Max Xcode Version | Notes |
-| --- | --- | --- | --- |
-| 10.1.0 - latest | 11.0.0 | 13.x | Full support for iOS 15 |
-| 10.0.0 - 10.0.2 | 11.0.0 | 12.x | Dropped iOS 11 support |
-| 9.3.0 - 9.3.2 | 11.0.0 | 12.x |  |
-| 9.2.0 - 9.2.2 | 11.0.0 | 12.x | Full support for iOS 14 and beta support for macOS via Mac Catalyst |
-| 9.0.0 - 9.1.0 | 9.0.0 | 11.x | Dropped iOS 9 support |
-| 8.3.0 - 8.3.1 | 8.0.0 | 11.x |  |
-| 8.2.0 - 8.2.1 | 8.0.0 | 11.x | Full support for iOS 13 |
-| 8.0.0 - 8.1.1 | 8.0.0 | 10.x |  |
-
-#### Unsupported versions of Xcode
-
-| Titanium SDK Version | Min Xcode Version | Max Xcode Version | Notes |
-| --- | --- | --- | --- |
-| 7.5.0 - 7.5.2 | 8.0.0 | 10.x |  |
-| 7.4.0 - 7.4.2 | 8.0.x | 10.x | Full support for iOS 12 |
-| 7.0.0 - 7.3.1 | 6.0.x | 9.0.x |  |
-| 6.3.0 | 6.0.x | 9.0.x |  |
-| 6.2.x | 6.0.x | 9.0.x | Full support for iOS 11 |
-| 5.5.x - 6.1.x | 6.0.x | 8.0.x |  |
-| 5.0.0 - 5.4.0 | 6.0.x | 7.0.x |  |
-| 4.0.0 - 4.1.x | 6.0.x | 6.4.x |  |
-| 3.4.0 - 3.5.x | 6.0.x | 6.0.x |  |
-
-Deploying for iOS 11.x requires Xcode 9.x, and macOS 10.12.4 and later.
-
-Deploying for iOS 12.x requires Xcode 10.x, and macOS 10.13.6 and later.
-
-As per apple guidelines, Starting April 2020 all apps submitted to App Store must be built with iOS 13 SDK or later, included in Xcode 11 or later.
-
-### iOS SDK / Target iOS platform
-
-Each Titanium SDK supports a specific range of iOS base SDKs and deployment targets. To build an application for a specific iOS target version, you must have the appropriate iOS SDK installed.
-
-#### Supported versions of iOS SDK / Target iOS platform
-
-| Titanium SDK version | Minimum iOS SDK version | Maximum iOS SDK version | Minimum target iOS version | Maximum target iOS version |
-| --- | --- | --- | --- | --- |
-| 10.1.0 - latest | 13.0.0 | 15.x | 12.0 | 15.x |
-| 10.0.0 - 10.0.2 | 13.0.0 | 14.x | 12.0 | 14.x |
-| 9.2.0 - 9.3.x | 13.0.0 | 14.x | 10.0 | 14.x |
-| 9.0.0 - 9.1.2 | 11.0.0 | 13.x | 10.0 | 13.x |
-| 8.2.0 - 8.3.1 | 10.0.0 | 13.x | 9.0 | 13.x |
-| 8.0.0 - 8.1.1 | 10.0.0 | 12.x | 9.0 | 12.x |
-
-#### Unsupported versions of iOS SDK / Target iOS platform
-
-| Titanium SDK version | Minimum SDK version | Maximum SDK version | Minimum target iOS version | Maximum target iOS version |
-| --- | --- | --- | --- | --- |
-| 7.4.0 - 7.5.x | 8.0.0 | 12.x | 8.0 | 12.x |
-| 7.0.0 - 7.3.x | 8.0.0 | 11.x | 8.0 | 12.x |
-| 6.2.0 - 6.3.x | 8.0.x | 11.x | 8.0 | 12.x |
-| 6.0.0 - 6.1.x | 8.0.x | 10.x | 8.0 | 12.x |
-| 5.5.x | 8.0.x | 10.x | 7.1.x | 9.3.x |
-| 5.0.0 - 5.4.x | 8.0.x | 9.3.x | 7.1.x | 9.3.x |
-| 4.0.0 - 4.1.x | 8.0.x | 8.4.x | 7.1.x | 8.4.x |
-| 3.4.0 - 3.5.x | 8.0.x | 8.0.x | 7.1.x | 8.0.x |
-| 3.2.2 - 3.3.0 | 7.0.x | 7.1.x | 6.1.x | 7.1.x |
-| 3.1.3 - 3.2.1 | 7.0.x | 7.0.x | 6.1.x | 7.0.x |
-| 3.1.1 - 3.1.2 | 5.0.x | 6.1.x | 5.0.x | 6.1.x |
-| 3.1.0 | 4.3.x | 6.1.x | 4.3.x | 6.1.x |
-| 2.1.3 - 3.0.x | 4.0.x | 6.1.x | 4.0.x | 6.1.x |
-| 2.1.0 - 2.1.2 | 4.0.x | 5.1.x | 4.0.x | 5.1.x |
-| 2.0.x | 4.0.x | 5.1.x | 4.0.x | 5.1.x |
-| 1.8.x | 4.0.x | 5.0.x | 4.0.x | 5.0.x |
-| 1.7.1+ | 3.1.2 | 5.0.x | 3.1.2 | 5.0.x |
 
 ## Installation (iOS-only)
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Titanium_Compatibility_Matrix/README.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Titanium_Compatibility_Matrix/README.md
@@ -101,7 +101,7 @@ Titanium can provide a development environment for third-party mobile platforms 
 
 ### Android
 
-See [Installing the Android SDK](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_Android_SDK.html) for detailed instructions.
+See [Installing the Android SDK](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_Android_SDK.html) for detailed instructions. Since Titanium SDK 12.0.0 we target and support Android 13 by default.
 
 Titanium requires the Android SDK Tools to be installed in order to allow you to develop Android applications.
 
@@ -135,13 +135,13 @@ Each Titanium SDK supports building against a specific range of Android versions
 | --- | --- | --- | --- |
 | 12.0.0 - latest\* | 6.0.x (API 23) | 13.0.x (API 33) | 5.0.x (API 21) |
 | 10.1.0 - 11.1.1 | 6.0.x (API 23) | 12.0.x (API 31) | 5.0.x (API 21) |
-| 10.0.0 - 10.0.2 | 6.0.x (API 23) | 11.0.x (API 30) | 5.0.x (API 21) |
 
 <details>
 <summary><b>Unsupported versions</b></summary>
 
 | Titanium SDK Version | Min Target Android Version  <br />(android:targetSdkVersion) | Max Target Android Version  <br />(android:targetSdkVersion) | Min Supported Android Version  <br />(android:minSdkVersion) |
 | --- | --- | --- | --- |
+| 10.0.0 - 10.0.2 | 6.0.x (API 23) | 11.0.x (API 30) | 5.0.x (API 21) |
 | 9.3.0 - 9.3.2 | 6.0.x (API 23) | 11.0.x (API 30) | 4.4.x (API 19) |
 | 8.3.0 - 9.2.2 | 6.0.x (API 23) | 10.0.x (API 29) | 4.4.x (API 19) |
 | 8.0.0 - 8.2.2 | 6.0.x (API 23) | 9.0.x (API 28) | 4.4.x (API 19) |


### PR DESCRIPTION
* adjusted the FAQ text of the `Unable to find an iOS Simulator` solutions
* removed the compatibility tables from the Android and iOS page and link the the normal compt. matrix (that way we only have to maintain one table!)
* added a small note that we support "Android 13" in the matrix page
* move one old 10.0.x line from the matrix SDK table into the drop-down of old versions