### PR TITLE
fix submenu order

### DIFF
--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.0.0.GA_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.0.0.GA_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.0.0.GA - 30 December 2022
-weight: '20'
+weight: '11'
 ---
 
 # Titanium SDK 12.0.0.GA Release Note

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.0.GA_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.0.GA_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.1.0.GA - 24 April 2023
-weight: '20'
+weight: '13'
 ---
 
 # Titanium SDK 12.1.0.GA Release Note

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.0.RC_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.0.RC_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.1.0.RC - 3 April 2023
-weight: '10'
+weight: '12'
 ---
 
 # Titanium SDK 12.1.0.RC Release Note

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.1.GA_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.1.GA_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.1.1.GA - 28 April 2023
-weight: '20'
+weight: '14'
 ---
 
 # Titanium SDK 12.1.1.GA Release Note

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.2.GA_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.1.2.GA_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.1.2.GA - 2 June 2023
-weight: '20'
+weight: '15'
 ---
 
 # Titanium SDK 12.1.2.GA Release Note

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.2.0.GA_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.2.0.GA_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.2.0.GA - 15 August 2023
-weight: '10'
+weight: '17'
 ---
 
 # Titanium SDK 12.2.0.GA Release Note

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.2.0.RC_Release_Note.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Release_Notes/Titanium_SDK_Release_Notes_12.x/Titanium_SDK_12.2.0.RC_Release_Note.md
@@ -1,6 +1,6 @@
 ---
 title: Titanium SDK 12.2.0.RC - 11 August 2023
-weight: '10'
+weight: '16'
 ---
 
 # Titanium SDK 12.2.0.RC Release Note


### PR DESCRIPTION
Adjusting the weights so RC and GA are in the correct order and the latest is at the bottom:

![Screenshot_20230915_194549](https://github.com/tidev/titanium-docs/assets/4334997/82572716-bd53-42f5-b8a8-db6cc44e34b7)
