### PR TITLE
Various doc updates

### DIFF
--- a/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_FAQ.md
@@ -305,9 +305,9 @@ Your system environment must meet the following requirements:
 
 * **Memory:** 8 GB RAM minimum system memory (2 GB RAM available memory). 16 GB RAM recommended.
 
-* **Java Runtime:** Oracle JDK (no other brand of Java is suitable)
+* **Java Runtime:** Java JDK like Oracle JDK or OpenJDK
 
-* **Node.js:** Required for the Titanium command-line tools like the CLI, Alloy and AMPLIFY Runtime Services
+* **Node.js:** Required for the Titanium command-line tools like the CLI and Alloy
 
 ::: tip 💡 Hint
 For Windows, you can use either 32-bit or 64-bit versions of Java JDK. Please refer to [Studio Java Support](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Titanium_Compatibility_Matrix/Studio_Java_Support/) for more information.

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/README.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/README.md
@@ -5,29 +5,7 @@ weight: '20'
 
 # Installing Platform SDKs
 
-To develop native mobile applications with Titanium you need to have the SDKs installed for your target platform. For instance, to develop Android applications you need the Android SDK and toolchain installed, and Xcode to develop iOS applications. You can either use Studio's Platform Configuration tool to automate the installation process or install these SDKs manually.
-
-## Studio Platform Configuration Tool
-
-Studio provides the Platform Configuration tool to make it easier to install, configure and update native platform SDKs on your system. This tool is automatically launched when Studio first starts after being installed, or when creating a new project with an unconfigured platform. You may also launch the tool through the Studio Dashboard **Get Started** tab by selecting an SDK to configure.
-
-When the **Platform Configuration** dialog opens, this dialog indicates which platform SDKs are installed and which are not, and lets you easily install individual SDKs.
-
-In the dialog, select the SDKs you want to install and optionally click **Settings** to specify a few basic settings for each (described in more detail the below sections). Click **Configure** to start the installation process.
-
-Studio begins downloading and installing each SDK you selected, according to the settings you specified. In the case of iOS, Studio launches the App Store application installed on your Mac to the Xcode download page.
-
-### Android settings
-
-You specify where to install the SDK and which versions to install. To build applications for other versions of Android, select the appropriate Android SDKs from the settings view.
-
-### iOS settings
-
-There aren't any special settings for iOS, as you only need to install the Xcode developer toolset.
-
-## Manual Installation
-
-For advanced platform configurations or setting up the platform SDKs for use with the Titanium CLI, refer to the following installation guides:
+To develop native mobile applications with Titanium you need to have the SDKs installed for your target platform. For instance, to develop Android applications you need the Android SDK and toolchain installed, and Xcode to develop iOS applications. 
 
 * [Installing the Android SDK](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_Android_SDK/)
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Prerequisites/Installing_Node.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Prerequisites/Installing_Node.md
@@ -9,7 +9,7 @@ Node.js is required for several Appcelerator components, including the Titanium 
 
 ## Compatibility and download
 
-To run all Appcelerator components, you must have Node.js 10.13.0 or later.
+To run all Appcelerator components, you must have Node.js 14.x or later.
 
 On Mac OS X and Windows, if you have selected to install Titanium updates, Studio prompts you to install Node.js. On Linux, you need to manually install Node.js.
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/README.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Getting_Started/README.md
@@ -17,7 +17,7 @@ Your system environment must meet the following requirements:
 
 * **Memory:** 8 GB RAM minimum system memory (2 GB RAM available memory). 16 GB RAM recommended.
 
-* **Java Runtime:** Oracle JDK (no other brand of Java is suitable)
+* **Java Runtime:** Java JDK like Oracle JDK or OpenJDK
 
 * **Node.js:** Required for the Titanium command-line tools like the CLI or Alloy
 
@@ -37,7 +37,10 @@ Our recommendations for an IDE, are to use VSCode or Atom. There exists specific
 
 To develop native applications with Titanium you need the SDKs and tools for those native platforms installed on your system. For example, to develop Android applications you need the Android SDK and toolchain installed, and for iOS (only available in a MacOS system) you need the iOS SDK.
 
-For detailed instructions, see [Installing Platform SDKs](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/).
+For detailed instructions, see:
+* [Installing the Android SDK](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_Android_SDK/)
+
+* [Installing the iOS SDK](/guide/Titanium_SDK/Titanium_SDK_Getting_Started/Installation_and_Configuration/Installing_Platform_SDKs/Installing_the_iOS_SDK/)
 
 ## First Titanium app
 

--- a/docs/guide/Titanium_SDK/Titanium_SDK_Guide/Titanium_Command-Line_Interface_Reference/README.md
+++ b/docs/guide/Titanium_SDK/Titanium_SDK_Guide/Titanium_Command-Line_Interface_Reference/README.md
@@ -39,10 +39,10 @@ For more information, see [Installing Node](/guide/Titanium_SDK/Titanium_SDK_Get
     npm install titanium -g
     ```
 
-2. Download the latest UNSTABLE Titanium SDK continuous integration build.
+2. Download the latest Titanium SDK.
 
     ```
-    titanium sdk install --branch master --default
+    titanium sdk install --default
     ```
 
 3. Configure CLI (optional).
@@ -177,7 +177,7 @@ ti clean [ --platform <platform> ] [--project-dir <value>] [--sdk <value>] [--lo
 ```
 
 ::: warning ⚠️ Warning
-As of Titanium SDK 7.3.0 release, you need to keep historical version of your module in your `dist` folder in a safe place (e.g. source control). Running this updated command will wipe out anything in the `dist` folder.
+You need to keep historical version of your module in your `dist` folder in a safe place (e.g. source control). Running this updated command will wipe out anything in the `dist` folder.
 :::
 
 **Best practice**: don't use releases as a means of archiving. Releases should be published in a stable location such as Github, S3, etc. But, if you wish to keep old releases in the module, you should consider using a different folder to archive your content in the `dist` folder and commit that zip to your source control before cleaning.
@@ -380,15 +380,13 @@ Downloads the latest Titanium SDK or a specific version.
 
 ```bash
 # Titanium CLI
-# Can only install Titanium SDK 4.0.0.GA and older or UNSTABLE continuous integration builds
 titanium sdk install [<version>] [--default] [--force] [--branch <branch name>]
 
 # Titanium CLI
-# Can install any GA Titanium SDK release or UNSTABLE continuous integration build
 ti sdk install [<version>] [--default] [--force] [--branch <branch name>]
 ```
 
-`<version>` may be either a specific version number, such as `3.1.3.GA` or a URL to a continuous integration build, such as `http://builds.appcelerator.com.s3.amazonaws.com/mobile/3_1_X/mobilesdk-3.1.3.v20130904134612-osx.zip`.
+`<version>` may be either a specific version number, such as `12.2.0.GA`, a URL like `https://nightly.link/tidev/titanium-sdk/actions/runs/6285955863/mobilesdk-12.3.0.v20230923211249-linux.zip` or a ZIP file if you downloaded a build locally.
 
 To override this behavior, set the `sdk.defaultInstallLocation` key to a path where you want to install the SDKs, for example:
 


### PR DESCRIPTION
* change some "Oracle JDK only" to include OpenJDK 
* removing the "Studio SDK configuration" part and just list the manual way
* clean up the "install SDK" basic page.