### PR TITLE
fix: property tables

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -199,3 +199,15 @@ ol li {
   margin-top: 70px;
   line-height: 1.8rem;
 }
+
+.parameter-table {
+  table-layout: fixed;
+}
+
+.parameter-table thead th:first-child {
+  width: 20%;
+}
+
+.main-docs-wrapper .content:not(.custom) {
+  max-width: 1024px;
+}


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-docs/issues/249

* making table layout "fixed" so long code in a td won't break the layout.
* making the content a bit wider
* making the first table row of the property table a bit smaller. It's a property name, most/all are not that long and this will give us a bit more space for the type and description


before:
<img width="1380" height="758" alt="Bildschirmfoto_20251004_173226" src="https://github.com/user-attachments/assets/7757cdc2-6bb9-49cd-9bd6-0e2a5cf82fe3" />

after:
<img width="1438" height="752" alt="Bildschirmfoto_20251004_173524" src="https://github.com/user-attachments/assets/107727ad-b540-4bc2-9f77-7b4f3a8a993e" />
